### PR TITLE
Adds support for the New Relic module's compile time dexer agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-Appcelerator Titanium Mobile
+[DEPRECATED] Appcelerator Titanium Mobile
+=============================
+
+New Relic has deprecated Titanium support and is not actively contibuting to this repo. Please reach out to support@newrelic.com with any questions.
+
 =============================
 
 For details on Titanium, please see <http://www.appcelerator.com>.

--- a/scripts/android/builder.py
+++ b/scripts/android/builder.py
@@ -1953,6 +1953,24 @@ class Builder(object):
 					dex_args = [self.java, '-Xmx1024M', '-Djava.ext.dirs=%s' % self.sdk.get_platform_tools_dir(), '-jar', self.sdk.get_dx_jar()]
 				else:
 					dex_args = [dx, '-JXmx1536M', '-JXX:-UseGCOverheadLimit']
+
+				# Look for New Relic module
+				newrelic_module = None
+				for module in self.modules:
+					if module.path.find("newrelic") > 0:
+						newrelic_module = module
+						break
+				
+				# If New Relic is present, add its Java agent to the dex arguments.
+				if newrelic_module:
+					info("Adding New Relic support.")
+
+					# Copy the dexer java agent jar to a tempfile. Eliminates white space from
+					# the module path which causes problems with the dex -Jjavaagent argument.
+					temp_jar = tempfile.NamedTemporaryFile(suffix='.jar', delete=True)
+					shutil.copyfile(os.path.join(newrelic_module.path, 'class.rewriter.jar'), temp_jar.name)
+					dex_args += ['-Jjavaagent:' + os.path.join(temp_jar.name)]
+				
 				dex_args += ['--dex', '--output='+self.classes_dex, self.classes_dir]
 				dex_args += self.android_jars
 				dex_args += self.module_jars


### PR DESCRIPTION
New Relic for Android requires an additional argument to be passed to the Android SDK dx command when it is invoked at compile time. This PR looks for the New Relic Titanium module and if present, appends an argument to the dexer so that New Relic instrumentation occurs.

The file passed to the dexer is a temporary file. This is because the dex argument does not like spaces in the filename, and under OSX at least the module directory is very likely to have spaces in it, due to 'Application Support' etc. The temporary file is cleaned up automatically after the dexing phase is done.
